### PR TITLE
Make PR update step in CI case insensitive

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,6 +11,44 @@ on:
       - master
 
 jobs:
+  uncheck-integration-test:
+    name: Mark integration test as not run
+    runs-on: ubuntu-20.04
+    if: github.event_name == 'pull_request'
+    steps:
+      - id: get-pr-body
+        name: Get the current PR body
+        uses: jwalton/gh-find-current-pr@v1
+        with:
+          state: open
+
+      - id: create-unchecked-pr-body
+        name: Create unchecked PR body
+        run: |-
+          UNCHECKED_BODY=$(sed 's/- \[[Xx]\] Started end-to-end tests on the latest commit./- \[ \] Started end-to-end tests on the latest commit./' <<\EOF
+          ${{ steps.get-pr-body.outputs.body }}
+          EOF
+          )
+
+          UNCHECKED_BODY="${UNCHECKED_BODY//'%'/'%25'}"
+          UNCHECKED_BODY="${UNCHECKED_BODY//$'\n'/'%0A'}"
+          UNCHECKED_BODY="${UNCHECKED_BODY//$'\r'/'%0D'}"
+
+          echo "Unchecked PR body"
+          echo $UNCHECKED_BODY
+
+          echo "::set-output name=body::$UNCHECKED_BODY"
+
+      - id: uncheck-integration-checkbox
+        name: Uncheck the integration checkbox
+        uses: tzkhan/pr-update-action@v2
+        with:
+          repo-token: "${{ secrets.API_TOKEN_GITHUB }}"
+          head-branch-regex: "${{ github.head_ref }}"
+          lowercase-branch: false
+          body-template: "${{  steps.create-unchecked-pr-body.outputs.body }}"
+          body-update-action: "replace"
+
   build-docker:
     name: Build Docker container
     runs-on: ubuntu-20.04
@@ -36,7 +74,6 @@ jobs:
           REF_ID=$(echo $GITHUB_REF | sed 's/\//-/g')
 
           echo THIS BUILD HOTFIX/RELEASE IS RUNNING!! WOOT!
-          
 
           # the final tag is something like:
           # refs-heads-master-a4f8bc313dae

--- a/.github/workflows/pr_validate.yaml
+++ b/.github/workflows/pr_validate.yaml
@@ -11,7 +11,7 @@ jobs:
   lint-pr-body:
     name: Lint pull request body
     runs-on: ubuntu-20.04
-    concurrency: 
+    concurrency:
       group: ${{ github.head_ref }}
       cancel-in-progress: true
     outputs:
@@ -185,7 +185,7 @@ jobs:
         uses: jwalton/gh-find-current-pr@v1
         with:
           state: open
-          
+
       - id: create-unchecked-pr-body
         if: failure()
         name: Create unchecked PR body
@@ -211,5 +211,6 @@ jobs:
         with:
           repo-token: "${{ secrets.API_TOKEN_GITHUB }}"
           head-branch-regex: '${{ github.head_ref }}'
+          lowercase-branch: false
           body-template: "${{  steps.create-unchecked-pr-body.outputs.body }}"
           body-update-action: 'replace'


### PR DESCRIPTION
# Description
- Make PR update step in CI case insensitive
- Auto uncheck integration test box

# Details
#### URL to issue
N/A

#### Link to staging deployment URL (or set N/A)
N/A

#### Links to any PRs or resources related to this PR
https://github.com/hms-dbmi-cellenics/api/pull/291

#### Integration test branch
master

# Merge checklist
Your changes will be ready for merging after all of the steps below have been completed.

### Code updates
Have best practices and ongoing refactors being observed in this PR
- [ ] Migrated any selector / reducer used to the new format.

### Manual/unit testing
- [X] Tested changes using InfraMock locally **or** no tests required for change, e.g. Kubernetes chart updates.
- [X] Validated that current unit tests for code work as expected and are sufficient for code coverage **or** no unit tests required for change, e.g. documentation update.
- [X] Unit tests written **or** no unit tests required for change, e.g. documentation update.

### Integration testing
**You must check the box below** to run integration tests on the latest commit on your PR branch.
Integration tests have to pass before the PR can be merged. Without checking the box, your PR
**will not pass** the required status checks for merging.

- [ ] Started end-to-end tests on the latest commit.

### Documentation updates
- [ ] Relevant Github READMEs updated **or** no GitHub README updates required.
- [ ] Relevant Wiki pages created/updated **or** no Wiki updates required.

### Optional
- [ ] Staging environment is unstaged before merging.
- [ ] Photo of a cute animal attached to this PR.