### PR TITLE
Add troubleshooting section in Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,10 +101,10 @@ load('{task_name}_{sample_id}.RData', envir = task_env)
 
 #### Linux Mint 20.3 Cinnamon
 ```bash
-gem2s-runner-YZCcIZIOME | Error in curl::curl_fetch_memory(url, handle = handle) : 
-gem2s-runner-YZCcIZIOME |   Timeout was reached: [172.17.0.1:4566] Connection timeout after 60001 ms
-gem2s-runner-YZCcIZIOME | Calls: init ... request_fetch -> request_fetch.write_memory -> <Anonymous>
-gem2s-runner-YZCcIZIOME | Execution halted
+Error in curl::curl_fetch_memory(url, handle = handle) : 
+Timeout was reached: [172.17.0.1:4566] Connection timeout after 60001 ms
+Calls: init ... request_fetch -> request_fetch.write_memory -> <Anonymous>
+Execution halted
 ```
 Turn off firewall or allow incoming traffic. This would allow AWS to send packages to the pipeline, which would otherwise be blocked by the firewall.
 


### PR DESCRIPTION
Add troubleshooting section in Readme and describe an error that occurs when a firewall blocks docker connection with aws.