### PR TITLE
Using a whole-file default value for region

### DIFF
--- a/local-runner/src/app.js
+++ b/local-runner/src/app.js
@@ -5,6 +5,10 @@ const DockerEvents = require('docker-events');
 const { pt } = require('prepend-transform');
 const chalk = require('chalk');
 
+// set default values for the AWS region because otherwise setVarsInTemplate function
+// will silently fail
+process.env.AWS_DEFAULT_REGION = process.env.AWS_DEFAULT_REGION || 'eu-west-1';
+
 // Enable & connect to local Inframock.
 AWS.config.update({
   endpoint: 'http://localhost:4566',
@@ -33,7 +37,7 @@ const initStack = async () => {
 
   console.log('Creating mock Lambda function on InfraMock...');
   const cf = new AWS.CloudFormation({
-    region: process.env.AWS_DEFAULT_REGION || 'eu-west-1',
+    region: process.env.AWS_DEFAULT_REGION,
   });
 
   const stackName = {


### PR DESCRIPTION
# Description
Due to recent modifications to `app.js` setting up the `AWS_DEFAULT_REGION` env variable was required. The error was very obscure, because when creating the lambda function is uses a default with region: `process.env.AWS_DEFAULT_REGION || 'eu-west-1'`. However, when adding the variable to the template it does not (which is the latest addition) causing the pipeline to fail once it started.

I modified the code to set the default for the whole file instead of just for one of the cases.
# Details
#### URL to issue
N/A

#### Link to staging deployment URL (or set N/A)
N/A

#### Links to any PRs or resources related to this PR

#### Integration test branch
master
<!---
  The branch of the integration test this PR will be run against

  If you DID NOT modify the integration tests for this PR, this can be left as `master`.

  If you DID modify the integration tests for this PR, add the name of the branch you created
  in hms-dbmi-cellenics/testing that will be used to test this branch.
-->

# Merge checklist
Your changes will be ready for merging after all of the steps below have been completed.
<!---
  The required checks will not pass until all the boxes below have been checked.
-->

### Code updates
Have best practices and ongoing refactors being observed in this PR
- [ ] Migrated any selector / reducer used to the new format.

### Manual/unit testing
- [ ] Tested changes using InfraMock locally **or** no tests required for change, e.g. Kubernetes chart updates.
- [ ] Validated that current unit tests for code work as expected and are sufficient for code coverage **or** no unit tests required for change, e.g. documentation update.
- [ ] Unit tests written **or** no unit tests required for change, e.g. documentation update.

<!---
  Download the latest production data using `cellenics experiment pull`.
  To set up easy local testing with inframock, follow the instructions here: https://github.com/hms-dbmi-cellenics/inframock
  To deploy to the staging environment, follow the instructions here: https://github.com/hms-dbmi-cellenics/cellenics-utils
-->

### Integration testing
**You must check the box below** to run integration tests on the latest commit on your PR branch.
Integration tests have to pass before the PR can be merged. Without checking the box, your PR
**will not pass** the required status checks for merging.

- [ ] Started end-to-end tests on the latest commit.

### Documentation updates
- [ ] Relevant Github READMEs updated **or** no GitHub README updates required.
- [ ] Relevant Wiki pages created/updated **or** no Wiki updates required.

### Optional
- [ ] Staging environment is unstaged before merging.
- [ ] Photo of a cute animal attached to this PR.