### PR TITLE
fix(subset-pipeline): metadata with regex chars

### DIFF
--- a/pipeline-runner/R/gem2s-7-upload_to_aws.R
+++ b/pipeline-runner/R/gem2s-7-upload_to_aws.R
@@ -256,7 +256,9 @@ get_metadata_cell_ids <- function(scdata_list, valid_metadata_name, value) {
 extract_subset_user_metadata <- function(subset_cellsets) {
   # metadata keys are the <track_name>-<value>, and name are the values alone
   metadata <- unique(subset_cellsets[type == "metadata"], by = "key")
-  metadata[, metadata_track := gsub(paste0("-", name, "$"), "", key), by = "key"]
+  # escape regex characters to avoid errors when creating cellsets
+  metadata[, escaped_name := gsub("([.\\\\+*?\\[^\\]$(){}=!<>|:-])", "\\\\\\1", name, perl = TRUE)]
+  metadata[, metadata_track := gsub(paste0("-", escaped_name, "$"), "", key), by = "key"]
 
   metadata <- metadata[, c("metadata_track", "name")]
   data.table::setnames(metadata, "name", "metadata_value")

--- a/pipeline-runner/tests/testthat/test-gem2s-7-upload_to_aws.R
+++ b/pipeline-runner/tests/testthat/test-gem2s-7-upload_to_aws.R
@@ -582,14 +582,13 @@ test_that("extract_subset_user_metadata extracts subset cellsets correctly when 
 
   # create new metadata cellsets with some annoying symbols
   new_parent_cellsets <- data.table::copy(parent_cellsets[type == "metadata"])
-  n <- floor(nrow(new_parent_cellsets)/2)
-  new_parent_cellsets[1:n, `:=`(key = "metadata_var-2-value_A+", name = "value_A+")]
-  new_parent_cellsets[n:.N, `:=`(key = "metadata_var-2-value_B-", name = "value_B-")]
+  new_parent_cellsets[1:.N/2, `:=`(key = "metadata_var-2-value_A+", name = "value_A+")]
+  new_parent_cellsets[(.N/2):.N, `:=`(key = "metadata_var-2-value+_B-", name = "value+_B-")]
   parent_cellsets <- data.table::rbindlist(list(parent_cellsets, new_parent_cellsets))
 
   res <- extract_subset_user_metadata(parent_cellsets)
 
   expect_equal(names(res), c("metadata_var-1", "metadata_var-2"))
   expect_equal(res[[1]], c("value_A", "value_B"))
-  expect_equal(res[[2]], c("value_A+", "value_B-"))
+  expect_equal(res[[2]], c("value_A+", "value+_B-"))
 })


### PR DESCRIPTION
# Description
When sample cellsets contain regex characters, subsetting an experiment fails. This is caused by the pattern matching used to extract the sample metadata track names from the cellsets object. 

For example, if an experiment contains a track `metadata_var` with values `value_1+`, and `value_1-` the experiment will have a cell class `metadata_var` with two cellsets (note the `key` and `name`):

```
{
key: "metadata_var-value_1+",
name: "value_1+",
type: "metadataCategorical",
...
},
{
key: "metadata_var-value_1-",
name:"value_1-",
type: "metadataCategorical",
...
}

```

To extract the variable name, we currently pattern match the name in the key using `gsub`. But the `+` is interpreted as a regex character, which makes the replacement incorrect (but does not fail).

The solution is to escape regex characters, and is what is implemented in this PR.


# Details
#### URL to issue
N/A

#### Link to staging deployment URL (or set N/A)
https://ui-german-pipeline7.scp-staging.biomage.net/

#### Links to any PRs or resources related to this PR
<!---
  Delete this comment and include the URLs of any pull requests that are related to this PR.
  Place each PR on a new line.
-->

#### Integration test branch
master
<!---
  The branch of the integration test this PR will be run against

  If you DID NOT modify the integration tests for this PR, this can be left as `master`.

  If you DID modify the integration tests for this PR, add the name of the branch you created
  in hms-dbmi-cellenics/testing that will be used to test this branch.
-->

# Merge checklist
Your changes will be ready for merging after all of the steps below have been completed.
<!---
  The required checks will not pass until all the boxes below have been checked.
-->

### Code updates
Have best practices and ongoing refactors being observed in this PR
- [ ] Migrated any selector / reducer used to the new format.

### Manual/unit testing
- [ ] Tested changes using InfraMock locally **or** no tests required for change, e.g. Kubernetes chart updates.
- [ ] Validated that current unit tests for code work as expected and are sufficient for code coverage **or** no unit tests required for change, e.g. documentation update.
- [ ] Unit tests written **or** no unit tests required for change, e.g. documentation update.

<!---
  Download the latest production data using `cellenics experiment pull`.
  To set up easy local testing with inframock, follow the instructions here: https://github.com/hms-dbmi-cellenics/inframock
  To deploy to the staging environment, follow the instructions here: https://github.com/hms-dbmi-cellenics/cellenics-utils
-->

### Integration testing
**You must check the box below** to run integration tests on the latest commit on your PR branch.
Integration tests have to pass before the PR can be merged. Without checking the box, your PR
**will not pass** the required status checks for merging.

- [ ] Started end-to-end tests on the latest commit.

### Documentation updates
- [ ] Relevant Github READMEs updated **or** no GitHub README updates required.
- [ ] Relevant Wiki pages created/updated **or** no Wiki updates required.

### Optional
- [ ] Staging environment is unstaged before merging.
- [ ] Photo of a cute animal attached to this PR.
