### PR TITLE
HOTFIX: genes v umi filter not using user-defined parameters

### DIFF
--- a/pipeline-runner/R/qc-4-filter_gene_umi_outlier.R
+++ b/pipeline-runner/R/qc-4-filter_gene_umi_outlier.R
@@ -55,7 +55,7 @@ filter_gene_umi_outlier <- function(scdata_list, config, sample_id, cells_id, ta
   if (safeTRUE(config$auto))
     p_level <- min(0.001, 1 / ncol(sample_data))
   else
-    p_level <- config$filterSettings$regressionTypeSettings[[type]]$p.level
+    p_level <- 1 - config$filterSettings$predictionInterval
 
   p_level <- suppressWarnings(as.numeric(p_level))
   if(is.na(p_level)) stop("p_level couldn't be interpreted as a number.")

--- a/pipeline-runner/R/qc-4-filter_gene_umi_outlier.R
+++ b/pipeline-runner/R/qc-4-filter_gene_umi_outlier.R
@@ -55,7 +55,7 @@ filter_gene_umi_outlier <- function(scdata_list, config, sample_id, cells_id, ta
   if (safeTRUE(config$auto))
     p_level <- min(0.001, 1 / ncol(sample_data))
   else
-    p_level <- 1 - config$filterSettings$predictionInterval
+    p_level <- 1 - as.numeric(config$filterSettings$predictionInterval)
 
   p_level <- suppressWarnings(as.numeric(p_level))
   if(is.na(p_level)) stop("p_level couldn't be interpreted as a number.")

--- a/pipeline-runner/tests/testthat/test-qc-4-filter_gene_umi_outlier.R
+++ b/pipeline-runner/tests/testthat/test-qc-4-filter_gene_umi_outlier.R
@@ -164,6 +164,7 @@ test_that("Gene UMI filter works if input is a a float-interpretable string", {
   cells_id <- mock_ids()
   nstart <- ncol(scdata_list[[sample_2_id]])
   config$auto <- FALSE
+  config$filterSettings$predictionInterval <- "0.3"
 
   out_number <- filter_gene_umi_outlier(scdata_list, config, sample_2_id, cells_id)
 


### PR DESCRIPTION
# Description
The UI/API do not change the value of the p.level parameter sent in the config, but when auto is disabled, it adds a new `predictionInterval` parameter, which was not used at all in the pipeline, always defaulting to the auto estimated `p.level` value. Therefore changes to the filter did not produce the intended filtering.

This PR takes the `predictionInterval` parameter value and actually uses it to define the `p.level` parameter used by the `predict` function.

# Details
#### URL to issue
N/A

#### Link to staging deployment URL (or set N/A)
N/A

#### Links to any PRs or resources related to this PR
<!---
  Delete this comment and include the URLs of any pull requests that are related to this PR.
  Place each PR on a new line.
-->

#### Integration test branch
master
<!---
  The branch of the integration test this PR will be run against

  If you DID NOT modify the integration tests for this PR, this can be left as `master`.

  If you DID modify the integration tests for this PR, add the name of the branch you created
  in hms-dbmi-cellenics/testing that will be used to test this branch.
-->

# Merge checklist
Your changes will be ready for merging after all of the steps below have been completed.
<!---
  The required checks will not pass until all the boxes below have been checked.
-->

### Code updates
Have best practices and ongoing refactors being observed in this PR
- [ ] Migrated any selector / reducer used to the new format.

### Manual/unit testing
- [ ] Tested changes using InfraMock locally **or** no tests required for change, e.g. Kubernetes chart updates.
- [ ] Validated that current unit tests for code work as expected and are sufficient for code coverage **or** no unit tests required for change, e.g. documentation update.
- [ ] Unit tests written **or** no unit tests required for change, e.g. documentation update.

<!---
  Download the latest production data using `cellenics experiment pull`.
  To set up easy local testing with inframock, follow the instructions here: https://github.com/hms-dbmi-cellenics/inframock
  To deploy to the staging environment, follow the instructions here: https://github.com/hms-dbmi-cellenics/cellenics-utils
-->

### Integration testing
**You must check the box below** to run integration tests on the latest commit on your PR branch.
Integration tests have to pass before the PR can be merged. Without checking the box, your PR
**will not pass** the required status checks for merging.

- [ ] Started end-to-end tests on the latest commit.

### Documentation updates
- [ ] Relevant Github READMEs updated **or** no GitHub README updates required.
- [ ] Relevant Wiki pages created/updated **or** no Wiki updates required.

### Optional
- [ ] Staging environment is unstaged before merging.
- [ ] Photo of a cute animal attached to this PR.
