### PR TITLE
fix dates for make_vals_numeric

### DIFF
--- a/pipeline-runner/R/seurat-3-upload_seurat_to_aws.R
+++ b/pipeline-runner/R/seurat-3-upload_seurat_to_aws.R
@@ -161,6 +161,7 @@ find_cluster_columns <- function(scdata) {
 }
 
 make_vals_numeric <- function(vals) {
+  vals <- as.character(vals)
   as.numeric(factor(vals, levels = unique(vals)))
 }
 

--- a/pipeline-runner/tests/testthat/test-seurat-3-upload_seurat_to_aws.R
+++ b/pipeline-runner/tests/testthat/test-seurat-3-upload_seurat_to_aws.R
@@ -160,6 +160,19 @@ test_that("make_vals_numeric turns equivalent groups into identical vectors", {
   expect_failure(expect_identical(make_vals_numeric(vals1), bad_make_vals_numeric(vals2)))
 })
 
+test_that("make_vals_numeric works for columns with dates", {
+
+  # works when differently ordered
+  vals1 <- c('a', 'a', 'a', 'a', 'b', 'b', 'b')
+  vals2 <- as.Date(c(rep('1987-06-23', 4), rep('2017-02-07', 3)))
+  expect_identical(make_vals_numeric(vals1), make_vals_numeric(vals2))
+
+  old_make_vals_numeric <- function(vals) as.numeric(factor(vals, levels = unique(vals)))
+
+  expect_failure(expect_identical(make_vals_numeric(vals1), old_make_vals_numeric(vals2)))
+})
+
+
 test_that("add_metadata_to_input adds group metadata to input list", {
 
   scdata <- mock_scdata()


### PR DESCRIPTION
# Description
`make_vals_numeric` would produce all NAs for columns formatted as dates (e.g. classes `Date` or `POSIXct` or `POSIXt`) which results in an error from `test_groups_equal` (used by `find_cluster_columns`).  

This fixes that issue by coercing values to be character initially.

# Details
#### URL to issue
N/A

#### Link to staging deployment URL (or set N/A)
N/A

#### Links to any PRs or resources related to this PR
<!---
  Delete this comment and include the URLs of any pull requests that are related to this PR.
  Place each PR on a new line.
-->

#### Integration test branch
master
<!---
  The branch of the integration test this PR will be run against

  If you DID NOT modify the integration tests for this PR, this can be left as `master`.

  If you DID modify the integration tests for this PR, add the name of the branch you created
  in hms-dbmi-cellenics/testing that will be used to test this branch.
-->

# Merge checklist
Your changes will be ready for merging after all of the steps below have been completed.
<!---
  The required checks will not pass until all the boxes below have been checked.
-->

### Code updates
Have best practices and ongoing refactors being observed in this PR
- [ ] Migrated any selector / reducer used to the new format.

### Manual/unit testing
- [ ] Tested changes using InfraMock locally **or** no tests required for change, e.g. Kubernetes chart updates.
- [ ] Validated that current unit tests for code work as expected and are sufficient for code coverage **or** no unit tests required for change, e.g. documentation update.
- [ ] Unit tests written **or** no unit tests required for change, e.g. documentation update.

<!---
  Download the latest production data using `cellenics experiment pull`.
  To set up easy local testing with inframock, follow the instructions here: https://github.com/hms-dbmi-cellenics/inframock
  To deploy to the staging environment, follow the instructions here: https://github.com/hms-dbmi-cellenics/cellenics-utils
-->

### Integration testing
**You must check the box below** to run integration tests on the latest commit on your PR branch.
Integration tests have to pass before the PR can be merged. Without checking the box, your PR
**will not pass** the required status checks for merging.

- [ ] Started end-to-end tests on the latest commit.

### Documentation updates
- [ ] Relevant Github READMEs updated **or** no GitHub README updates required.
- [ ] Relevant Wiki pages created/updated **or** no Wiki updates required.

### Optional
- [ ] Staging environment is unstaged before merging.
- [ ] Photo of a cute animal attached to this PR.