### PR TITLE
make rename_active_ident work with factor+character

### DIFF
--- a/pipeline-runner/R/seurat-3-upload_seurat_to_aws.R
+++ b/pipeline-runner/R/seurat-3-upload_seurat_to_aws.R
@@ -83,10 +83,10 @@ upload_seurat_to_aws <- function(input, pipeline_config, prev_out) {
 rename_active_ident <- function(meta) {
 
   # determine columns that are duplicates of active.ident
-  test_vals <- meta$active.ident
+  test_vals <- as.character(meta$active.ident)
   dup.cols <- c()
   for (col in setdiff(colnames(meta), 'active.ident')) {
-    col_vals <- meta[[col]]
+    col_vals <- as.character(meta[[col]])
     if (identical(test_vals, col_vals))
       dup.cols <- c(dup.cols, col)
   }

--- a/pipeline-runner/tests/testthat/test-seurat-3-upload_seurat_to_aws.R
+++ b/pipeline-runner/tests/testthat/test-seurat-3-upload_seurat_to_aws.R
@@ -344,3 +344,21 @@ test_that("rename_active_ident does not rename active.ident when there isn't a d
   meta_renamed <- rename_active_ident(meta)
   expect_identical(meta, meta_renamed)
 })
+
+test_that("rename_active_ident works when one column is factor and the other is character", {
+
+  meta <- data.frame(
+    active.ident = c('cluster1', 'cluster2', 'cluster3'),
+    cell_type = factor(c('cluster1', 'cluster2', 'cluster3')),
+    other_clustering = c('clusterA', 'clusterA', 'clusterB')
+  )
+
+  expected_name <- 'cell_type'
+
+  meta_renamed <- rename_active_ident(meta)
+
+  expect_equal(colnames(meta_renamed)[1], expected_name)
+  expect_false('active.ident' %in% colnames(meta_renamed))
+  expect_equal(colnames(meta_renamed), c('cell_type', 'other_clustering'))
+})
+


### PR DESCRIPTION
# Description
If `active.ident` was factor and there is an identical `character` column then `rename_active_ident` didn't identify them as identical. This fixes that

# Details
#### URL to issue
N/A

#### Link to staging deployment URL (or set N/A)
N/A

#### Links to any PRs or resources related to this PR
<!---
  Delete this comment and include the URLs of any pull requests that are related to this PR.
  Place each PR on a new line.
-->

#### Integration test branch
master
<!---
  The branch of the integration test this PR will be run against

  If you DID NOT modify the integration tests for this PR, this can be left as `master`.

  If you DID modify the integration tests for this PR, add the name of the branch you created
  in hms-dbmi-cellenics/testing that will be used to test this branch.
-->

# Merge checklist
Your changes will be ready for merging after all of the steps below have been completed.
<!---
  The required checks will not pass until all the boxes below have been checked.
-->

### Code updates
Have best practices and ongoing refactors being observed in this PR
- [ ] Migrated any selector / reducer used to the new format.

### Manual/unit testing
- [ ] Tested changes using InfraMock locally **or** no tests required for change, e.g. Kubernetes chart updates.
- [ ] Validated that current unit tests for code work as expected and are sufficient for code coverage **or** no unit tests required for change, e.g. documentation update.
- [ ] Unit tests written **or** no unit tests required for change, e.g. documentation update.

<!---
  Download the latest production data using `cellenics experiment pull`.
  To set up easy local testing with inframock, follow the instructions here: https://github.com/hms-dbmi-cellenics/inframock
  To deploy to the staging environment, follow the instructions here: https://github.com/hms-dbmi-cellenics/cellenics-utils
-->

### Integration testing
**You must check the box below** to run integration tests on the latest commit on your PR branch.
Integration tests have to pass before the PR can be merged. Without checking the box, your PR
**will not pass** the required status checks for merging.

- [ ] Started end-to-end tests on the latest commit.

### Documentation updates
- [ ] Relevant Github READMEs updated **or** no GitHub README updates required.
- [ ] Relevant Wiki pages created/updated **or** no Wiki updates required.

### Optional
- [ ] Staging environment is unstaged before merging.
- [ ] Photo of a cute animal attached to this PR.