### PR TITLE
fix numeric names in cellsets

### DIFF
--- a/pipeline-runner/R/gem2s-7-upload_to_aws.R
+++ b/pipeline-runner/R/gem2s-7-upload_to_aws.R
@@ -222,7 +222,7 @@ build_metadata_cellsets <- function(input, scdata, color_pool, disable_qc_filter
 
       cell_set$children[[j]] <- list(
         "key" = paste(user_metadata_name, value, sep = "-"),
-        "name" = value,
+        "name" = as.character(value),
         "color" = color_pool[color_index],
         "cellIds" = unname(cell_ids)
       )

--- a/pipeline-runner/tests/testthat/test-gem2s-7-upload_to_aws.R
+++ b/pipeline-runner/tests/testthat/test-gem2s-7-upload_to_aws.R
@@ -301,6 +301,36 @@ test_that("get_cell_sets with two metadata groups matches snapshot", {
 })
 
 
+test_that("get_cell_sets converts numeric metadata values to strings", {
+  # Test case for issue: obj2s Seurat uploads with numeric sample-level metadata
+  # should have string names in cellsets, not numeric values
+  metadata <- list(Seq_Batch = list(1, 2, 2))
+  input <- mock_input(metadata)
+  config <- mock_config(input)
+  scdata_list <- mock_scdata_list(config)
+
+  cell_sets <- get_cell_sets(scdata_list, input)
+
+  # Get the Seq_Batch cellset
+  seq_batch_cellset <- NULL
+  for (cs in cell_sets$cellSets) {
+    if (cs$key == "Seq_Batch") {
+      seq_batch_cellset <- cs
+      break
+    }
+  }
+
+  expect_true(!is.null(seq_batch_cellset))
+  expect_equal(seq_batch_cellset$type, "metadataCategorical")
+
+  # Test that all children have string names, not numeric
+  for (child in seq_batch_cellset$children) {
+    expect_type(child$name, "character")
+    expect_true(child$name %in% c("1", "2"))
+  }
+})
+
+
 test_that("upload_to_aws tries to upload the correct files to aws", {
   metadata <- list(Group1 = list("Hello", "WT2", "WT2"), Group2 = list("WT", "WT", "WT124"))
   input <- mock_input(metadata)


### PR DESCRIPTION
# Description
This pull request addresses an issue where numeric sample-level metadata values were not being converted to strings in cellsets, which could cause downstream problems with data interpretation and display. The main changes ensure that all metadata values are represented as strings in cellsets and add a test to verify this behavior.

Metadata handling improvements:

* Modified the `build_metadata_cellsets` function to convert metadata values to strings when assigning to the `name` field in cellset children, ensuring consistent data types.

Testing enhancements:

* Added a unit test in `test-gem2s-7-upload_to_aws.R` to verify that numeric metadata values are converted to strings in cellsets, specifically for the `Seq_Batch` metadata group.

# Details
#### URL to issue
N/A

#### Link to staging deployment URL (or set N/A)
N/A
#### Links to any PRs or resources related to this PR
<!---
  Delete this comment and include the URLs of any pull requests that are related to this PR.
  Place each PR on a new line.
-->

#### Integration test branch
master
<!---
  The branch of the integration test this PR will be run against

  If you DID NOT modify the integration tests for this PR, this can be left as `master`.

  If you DID modify the integration tests for this PR, add the name of the branch you created
  in hms-dbmi-cellenics/testing that will be used to test this branch.
-->

# Merge checklist
Your changes will be ready for merging after all of the steps below have been completed.
<!---
  The required checks will not pass until all the boxes below have been checked.
-->

### Code updates
Have best practices and ongoing refactors being observed in this PR
- [x] Migrated any selector / reducer used to the new format.

### Manual/unit testing
- [x] Tested changes using InfraMock locally **or** no tests required for change, e.g. Kubernetes chart updates.
- [x] Validated that current unit tests for code work as expected and are sufficient for code coverage **or** no unit tests required for change, e.g. documentation update.
- [x] Unit tests written **or** no unit tests required for change, e.g. documentation update.

<!---
  Download the latest production data using `cellenics experiment pull`.
  To set up easy local testing with inframock, follow the instructions here: https://github.com/hms-dbmi-cellenics/inframock
  To deploy to the staging environment, follow the instructions here: https://github.com/hms-dbmi-cellenics/cellenics-utils
-->

### Integration testing
**You must check the box below** to run integration tests on the latest commit on your PR branch.
Integration tests have to pass before the PR can be merged. Without checking the box, your PR
**will not pass** the required status checks for merging.

- [ ] Started end-to-end tests on the latest commit.

### Documentation updates
- [ ] Relevant Github READMEs updated **or** no GitHub README updates required.
- [ ] Relevant Wiki pages created/updated **or** no Wiki updates required.

### Optional
- [ ] Staging environment is unstaged before merging.
- [ ] Photo of a cute animal attached to this PR.