### PR TITLE
Drop segmentation simplification, keep compact polygons

### DIFF
--- a/pipeline-runner/R/gem2s-2-load_user_files.R
+++ b/pipeline-runner/R/gem2s-2-load_user_files.R
@@ -1097,9 +1097,11 @@ read_visium_hd_sample <- function(sample, input_dir) {
     compact = FALSE
   )
 
-  # crop the image to the capture area, and rotate if width
-  # is less than height
+  # add the compact polygon boundary the crop/rotate transforms and the
+  # downstream GetTissueCoordinates(which = "segmentations") accessor read,
+  # crop the image to the capture area, and rotate if width is less than height
   results$segmentations <- segmentations |>
+    compact_segmentations() |>
     crop_to_capture_area() |>
     pivot_image_wide()
 
@@ -1130,21 +1132,17 @@ move_segmentations_to_subdir <- function(sample_dir) {
   )
 }
 
-simplify_segmentations <- function(segmentations) {
-  # tol determined empircally for visium hd
-  segmentations[["simplified.segmentations"]] <- SeuratObject::Simplify(
-    coords = segmentations[["segmentation"]],
-    tol = 5
-  )
-
-  # obtain compact coords
-  simplified_coords <- get_simplified_coords(segmentations)
-
-  # remove polygons to save memory
-  segmentations[["simplified.segmentations"]] <- SeuratObject::CreateSegmentation(
-    coords = simplified_coords,
-    compact = TRUE
-  )
+#' Add the compact polygon boundary set used downstream
+#'
+#' \code{Read10X_Segmentations} returns the cell polygons under the boundary
+#' name \code{segmentation} in expanded (sf) form. Store a compact copy
+#' (x/y/cell in \code{@sf.data}) under \code{segmentations} — the name both the
+#' crop/rotate transforms below and \code{GetTissueCoordinates(which =
+#' "segmentations")} in gem2s-7 read.
+#'
+#' @param segmentations VisiumV2 object with a \code{segmentation} boundary
+#' @return the object with an added compact \code{segmentations} boundary
+compact_segmentations <- function(segmentations) {
   segmentations[["segmentations"]] <- SeuratObject::CreateSegmentation(
     coords = segmentations[["segmentation"]]@sf.data,
     compact = TRUE
@@ -1165,12 +1163,12 @@ simplify_segmentations <- function(segmentations) {
 #' hires ratio, unaffected by cropping), so \code{coord * scale.factor} still
 #' lands correctly in the cropped image.
 #'
-#' Runs after \code{simplify_segmentations()} (all three boundaries present) and
-#' before \code{pivot_image_wide()} (rotation), transforming the image and all
-#' coordinate sets together, exactly as \code{rotate_visiumv2()} does.
+#' Runs after \code{compact_segmentations()} (centroids + segmentations present)
+#' and before \code{pivot_image_wide()} (rotation), transforming the image and
+#' all coordinate sets together, exactly as \code{rotate_visiumv2()} does.
 #'
-#' @param segmentations VisiumV2 object with centroids/segmentations/
-#'   simplified.segmentations boundaries and a tissue image
+#' @param segmentations VisiumV2 object with centroids/segmentations boundaries
+#'   and a tissue image
 #' @param margin_frac numeric fractional padding kept around the bounding box
 #'
 #' @return segmentations with the image cropped and coordinates re-offset
@@ -1178,8 +1176,7 @@ crop_to_capture_area <- function(segmentations, margin_frac = 0.02) {
   bounds <- segmentations@boundaries
   coords_list <- list(
     centroids = bounds[["centroids"]]@coords,
-    polygons = bounds[["segmentations"]]@sf.data,
-    polygons_simple = bounds[["simplified.segmentations"]]@sf.data
+    polygons = bounds[["segmentations"]]@sf.data
   )
 
   image <- segmentations@image
@@ -1226,7 +1223,6 @@ crop_to_capture_area <- function(segmentations, margin_frac = 0.02) {
 
   bounds[["centroids"]]@coords <- coords_shifted_list$centroids
   bounds[["segmentations"]]@sf.data <- coords_shifted_list$polygons
-  bounds[["simplified.segmentations"]]@sf.data <- coords_shifted_list$polygons_simple
   segmentations@boundaries <- bounds
   segmentations@image <- image[row_lo:row_hi, col_lo:col_hi, , drop = FALSE]
 
@@ -1257,8 +1253,7 @@ rotate_visiumv2 <- function(segmentations) {
   bounds <- segmentations@boundaries
   coords_list <- list(
     centroids = bounds[["centroids"]]@coords,
-    polygons = bounds[["segmentations"]]@sf.data,
-    polygons_simple = bounds[["simplified.segmentations"]]@sf.data
+    polygons = bounds[["segmentations"]]@sf.data
   )
 
   image <- segmentations@image
@@ -1311,30 +1306,10 @@ rotate_visiumv2 <- function(segmentations) {
   # update segmentations object
   bounds[["centroids"]]@coords <- coords_rot_list$centroids
   bounds[["segmentations"]]@sf.data <- coords_rot_list$polygons
-  bounds[["simplified.segmentations"]]@sf.data <- coords_rot_list$polygons_simple
   segmentations@boundaries <- bounds
   segmentations@image <- rotated_image
 
   return(segmentations)
-}
-
-get_simplified_coords <- function(segmentations) {
-  polygons <- segmentations[["simplified.segmentations"]]@polygons
-  coords_list <- lapply(
-    segmentations[["simplified.segmentations"]]@polygons,
-    function(x) {
-      x@Polygons[[1]]@coords
-    }
-  )
-
-  cells <- Seurat::Cells(segmentations)
-
-  ncoords <- sapply(coords_list, nrow)
-  coords <- do.call(rbind, coords_list)
-  colnames(coords) <- c("x", "y")
-  coords <- as.data.frame(coords)
-  coords$cell <- rep(cells, ncoords)
-  coords
 }
 
 

--- a/pipeline-runner/tests/testthat/test-gem2s-2-load_user_files_visium_hd.R
+++ b/pipeline-runner/tests/testthat/test-gem2s-2-load_user_files_visium_hd.R
@@ -47,10 +47,8 @@ make_test_segmentations <- function(image_width = 600, image_height = 500,
   )
 
   # add the polygon boundaries as compact segmentations (x/y/cell in @sf.data),
-  # matching the form simplify_segmentations() produces
+  # matching the form compact_segmentations() produces
   vis[["segmentations"]] <- SeuratObject::CreateSegmentation(seg_df, compact = TRUE)
-  vis[["simplified.segmentations"]] <-
-    SeuratObject::CreateSegmentation(seg_df, compact = TRUE)
   vis
 }
 


### PR DESCRIPTION
# Description

Fixes a regression in the Visium HD gem2s load step introduced by 8f462c0 ("not using simplified segs"). That commit removed the `simplify_segmentations()` call from the read pipe, but `crop_to_capture_area()` and `rotate_visiumv2()` still read the `segmentations` (plural) and `simplified.segmentations` boundaries that *only* `simplify_segmentations()` created. The forked BiocParallel worker therefore errored on a missing boundary right after reading `filtered_feature_cell_matrix.h5`, surfacing as the opaque:

```
Stop worker failed with the error: wrong args for environment subassignment
```

This PR drops the simplification for good while preserving the compact polygon boundary that is genuinely used downstream:

- Replaces `simplify_segmentations()` with a lean `compact_segmentations()` that only builds the compact `segmentations` boundary — no `SeuratObject::Simplify`, no `simplified.segmentations`.
- Restores the missing step in the read pipe: `compact_segmentations() |> crop_to_capture_area() |> pivot_image_wide()`.
- Removes all `simplified.segmentations` / `polygons_simple` handling from `crop_to_capture_area()` and `rotate_visiumv2()`, and deletes the now-dead `get_simplified_coords()`.
- Updates the test helper to stop building `simplified.segmentations`.

The plural `segmentations` boundary is kept because it's consumed downstream by `gem2s-7`'s `GetTissueCoordinates(..., which = "segmentations")` (for both Visium HD and Xenium). Only `simplified.segmentations` was actually unused.

> Note: this is a gem2s code change, so it needs a gem2s rebuild + forced rerun to take effect on existing datasets.

# Details


#### Link to staging deployment URL (or set N/A)
N/A

#### Links to any PRs or resources related to this PR
N/A

#### Integration test branch
master

# Merge checklist
Your changes will be ready for merging after all of the steps below have been completed.

### Code updates
Have best practices and ongoing refactors being observed in this PR
- [x] Migrated any selector / reducer used to the new format. (N/A — pipeline R change)

### Manual/unit testing
- [x] Tested changes using InfraMock locally **or** no tests required for change, e.g. Kubernetes chart updates.
- [x] Validated that current unit tests for code work as expected and are sufficient for code coverage **or** no unit tests required for change, e.g. documentation update.
- [x] Unit tests written **or** no unit tests required for change, e.g. documentation update.

`test-gem2s-2-load_user_files_visium_hd.R` (14/14) and `test-gem2s-5-create_seurat.R` (48/48) pass.

### Integration testing
**You must check the box below** to run integration tests on the latest commit on your PR branch.
Integration tests have to pass before the PR can be merged. Without checking the box, your PR
**will not pass** the required status checks for merging.

- [ ] Started end-to-end tests on the latest commit.

### Documentation updates
- [x] Relevant Github READMEs updated **or** no GitHub README updates required.
- [x] Relevant Wiki pages created/updated **or** no Wiki updates required.

### Optional
- [ ] Staging environment is unstaged before merging.
- [ ] Photo of a cute animal attached to this PR.